### PR TITLE
mongodb version update

### DIFF
--- a/resource/docker-compose.yaml
+++ b/resource/docker-compose.yaml
@@ -10,7 +10,7 @@ volumes:
 services:
   mongodb:
     container_name: mongo
-    image: mongo:latest
+    image: mongo:5.0.13
     restart: on-failure
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}


### PR DESCRIPTION
mongo 6.0.2 (latest) do not support some queries.
Fixed : Unsupported OP_QUERY command: count. The client driver may require an upgrade. For more details see https://dochub.mongodb.org/core/legacy-opcode-removal, code: 352, codeName: UnsupportedOpQueryCommand}